### PR TITLE
FIX #37

### DIFF
--- a/data-raw/hra2020_updates.R
+++ b/data-raw/hra2020_updates.R
@@ -9,7 +9,7 @@ library('DBI')
 newreg = st_read("//dphcifs/APDE-CDIP/Shapefiles/Region/region_hra20.shp")
 newhra = st_read('//dphcifs/APDE-CDIP/Shapefiles/HRA/hra_2020.shp')
 newhra = newhra[, c('id', 'name', 'reg_id', 'reg_nm')]
-zipo = st_read("//dphcifs/APDE-CDIP/Shapefiles/ZIP/zipcode.shp")
+zipo = st_read("//dphcifs/APDE-CDIP/Shapefiles_protected/ZIP/adci_wa_zip_raw.shp") # previously //dphcifs/APDE-CDIP/Shapefiles/ZIP/zipcode.shp
 tract10 = st_read("//dphcifs/APDE-CDIP/Shapefiles/Census_2010/tract/kc_tract.shp")
 tract20 = st_read("//dphcifs/APDE-CDIP/Shapefiles/Census_2020/tract/kc_tract.shp")
 blk10 = st_read("//dphcifs/APDE-CDIP/Shapefiles/Census_2010/block/kc_block.shp")
@@ -22,7 +22,7 @@ which_max_olap = function(x){
 # Note: The existing ZIP to region and School district
 # # generate crosswalks
 # # ZIP to region
-zip =  zipo %>% group_by(ZIP) %>% summarize()
+zip =  zipo %>% group_by(POSTCOD) %>% summarize() %>% rename(ZIP = POSTCOD)
 zip = st_transform(zip, st_crs(newreg))
 zip = reduce_overlaps(zip,snap = .5)
 # z2r_fo = create_xwalk(zip, newreg, source_id = 'ZIP', target_id = 'id', min_overlap = .1)
@@ -51,8 +51,9 @@ zip = reduce_overlaps(zip,snap = .5)
 # write.csv(z2r, file.path(outfol, 'zip_to_region2020.csv'), row.names = FALSE)
 
 # ZIP to HRA
-z2h_fo = create_xwalk(zip, newhra, source_id = 'ZIP', target_id = 'id', min_overlap = .1)
-z2h_fp = create_xwalk(zip, newhra, source_id = 'ZIP', target_id = 'id', min_overlap = .1,method = 'point pop',point_pop = kcparcelpop::parcel_pop, pp_min_overlap = .1)
+z2h_fo = create_xwalk(st_filter(zip, newhra), newhra, source_id = 'ZIP', target_id = 'id', min_overlap = .1)
+z2h_fp = create_xwalk(st_filter(zip, newhra), newhra, source_id = 'ZIP', target_id = 'id', min_overlap = .1,
+                      method = 'point pop',point_pop = kcparcelpop::parcel_pop, pp_min_overlap = .1)
 setDT(z2h_fo); setDT(z2h_fp);
 z2h_fo = merge(z2h_fo, newhra[, c('id', 'name'), drop = T], all.x = T, by.x = 'target_id', by.y = 'id')
 z2h_fp = merge(z2h_fp, newhra[, c('id', 'name'), drop = T], all.x = T, by.x = 'target_id', by.y = 'id')


### PR DESCRIPTION
 * Attempt to fix incorrect mapping ZIP to HRA20 by using a better zipcode shapefile
 
I know it is probably driving you bonkers that I won't let go of this issue. However, if you look at the attached PDF, I think you'll see that these xwalks are improvements because all the ZIP codes are at least adjacent to KC.
[zip_hra_comparisons.pdf](https://github.com/user-attachments/files/16852768/zip_hra_comparisons.pdf)

Also, in your spatagg README you give a stern warning about edge effects, especially for the point population method. After revising this crosswalk, I now see clearly what you mean. It looks like all the ZIPS at the perimeter that even partially overlap with KC are being fully ascribed to KC. This seems to be the case all the handful of pop xwalks in rads.data. I have no idea how that could be addressed in spatagg. However, in rads.data, I think we could partially address it by:
1) first, create the geographic / fractional xwalk
2) second, create the point pop xwalk
3) drop any source geos that do not show up in the geographic xwalk from those in the population xwalk. This is imperfect, but I think it would be better than ascribing the entire source to a given target. 

Thoughts? 